### PR TITLE
$pages uncountable...

### DIFF
--- a/blocks/page_list_plus/view.php
+++ b/blocks/page_list_plus/view.php
@@ -137,7 +137,7 @@ $wrapperClasses = implode(' ', $wrapperClasses);
             <?php endforeach; ?>
         </div>
 
-        <?php if (count($pages) == 0): ?>
+        <?php if (count($controller->pages) == 0): ?>
             <div class="ccm-block-page-list-no-pages"><?php echo $noResultsText ?></div>
         <?php endif; ?>
 


### PR DESCRIPTION
Was throwing uncountable warning on $pages.  Updated use of "$controller->pages" & casting as array "(array) $pages" both work...  Running smoothly otherwise, c5 8.5.4, PHP 7.2.33